### PR TITLE
Githubのセキュリティ警告に怒られたので修正

### DIFF
--- a/docker-django/django/requirements.base.txt
+++ b/docker-django/django/requirements.base.txt
@@ -1,4 +1,4 @@
-Django==2.1.10
+Django==2.1.1
 gunicorn==19.9.0
 psycopg2==2.7.5
 psycopg2-binary==2.7.5


### PR DESCRIPTION
Githubのセキュリティ警告に怒られたので、djangoの使用バージョンを上げた。
djangoのバージョン、しょっちゅう変わるね。